### PR TITLE
adding DISABLE_PEER_EXPIRY flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
         '-Wno-maybe-uninitialized',
         '-Wno-format-truncation',
         '-Wno-stringop-truncation',
+        '-DDISABLE_PEER_EXPIRY',
     ]
 else
     possible_cc_flags = []


### PR DESCRIPTION
Hi Sukchan!

I hope it's ok to submit a PR to this repository. It took me a bit to understand how the build system works with subprojects but now I think I have everything figured out.

This pull request adds the "DISABLE_PEER_EXPIRY" flag to the build. If DISABLE_PEER_EXPIRY is not added, after a hour of no traffic the Diameter connection between HSS/MME (or SMF/PCRF) will shut itself down (sending Disconnect-Peer-Request) and not bring itself back online. This creates a significant problem for long-term or prod deployments, and is hard to catch since it doesn't log anything at all, just silently fails. The next time that an app needs to send traffic (e.g. a new user comes online) Diameter just throws a ton of "Routing-Out" messages since it has no active connections anymore.