### PR TITLE
building acl_wl.fdx freeDiameter extension

### DIFF
--- a/extensions/acl_wl/meson.build
+++ b/extensions/acl_wl/meson.build
@@ -1,0 +1,21 @@
+lgen = generator(flex,
+      output : 'lex.@BASENAME@.c',
+          arguments : ['-p', '-Cem', '-Paw_conf', '-o', '@OUTPUT@', '@INPUT@'])
+lfiles = lgen.process('aw_conf.l')
+
+pgen = generator(bison,
+      output : ['@BASENAME@.tab.c', '@BASENAME@.tab.h'],
+          arguments : ['-p', 'aw_conf', '-d',
+                       '@INPUT@', '--defines=@OUTPUT1@', '--output=@OUTPUT0@'])
+pfiles = pgen.process('aw_conf.y')
+
+shared_module('acl_wl',
+      sources : [lfiles, pfiles, files(
+        'acl_wl.c',
+        'aw_tree.c')],
+      include_directories : freeDiameter_includes,
+      dependencies : libfdcore_dep,
+      name_prefix : '',
+      name_suffix : 'fdx',
+      install : true,
+      install_dir : freeDiameter_extensionsdir)

--- a/extensions/meson.build
+++ b/extensions/meson.build
@@ -45,3 +45,5 @@ shared_module('dict_dcca_3gpp',
   name_suffix : 'fdx',
   install : true,
   install_dir : freeDiameter_extensionsdir)
+
+subdir('acl_wl')


### PR DESCRIPTION
acl_wl is an optional freeDiameter extension that allows you to define groups of whitelisted communication endpoints (e.g. "*.localdomain") instead of a specific list of pre-approved endpoints (e.g. the "ConnectPeer" lines at the end of /etc/freeDiameter/{hss,mme,pcrf,smf}.conf). acl_wl is definitely needed if you want to run the HSS/PCRF in a "server mode", where it connects to an arbitrary number of MMEs/SMFs, or scale beyond what you anticipated. Otherwise, you have to add each and every peer as new "ConnectPeer" lines and then restart the HSS/PCRF to read the new .conf files.

This PR builds acl_wl.fdx as a part of freeDiameter, and then copies it into /usr/lib/x86_64-linux-gnu/freeDiameter when users install the open5gs-common package. It does not change any of the .conf files in /etc/freeDiameter, so acl_wl.fdx is not loaded by default. If more advanced system architects/integrators want to use acl_wl.fdx, it's already built so they can do so if they choose.

Compiling acl_wl.fdx needs flex and bison (to parse the .l and .y files) which is why I put it in its own meson subproject file (and copied some of the meson logic for flex/bison elsewhere in the code), as opposed to just adding it to extensions/meson.build. I have only tested this code on Ubuntu 20.04 but believe it should be platform-agnostic.