### PR TITLE
fix extensions/rt_default/meson.build

### DIFF
--- a/extensions/rt_default/meson.build
+++ b/extensions/rt_default/meson.build
@@ -1,5 +1,5 @@
-if cc.has_function('regexec', prefix : '#include <regex.h>')
-  conf_data = configuration_data()
+conf_data = configuration_data()
+if cc.has_header_symbol('regex.h', 'REG_STARTEND')
   conf_data.set('HAVE_REG_STARTEND', 1)
 endif
 configure_file(output : 'rt_default-host.h',


### PR DESCRIPTION
from extensions/rt_default/meson.build,
HAVE_REG_STARTEND is defined according to this block:

```
if cc.has_function('regexec', prefix : '#include <regex.h>')
  conf_data = configuration_data()
  conf_data.set('HAVE_REG_STARTEND', 1)
endif
```

However, this block is insufficient to determine
whether REG_STARTEND is defined, as not all regex.h contain the macro.

Something like the following in extensions/rt_ereg/CMakeLists.txt should be used instead:

```
CHECK_C_SOURCE_COMPILES("${CHECK_REG_STARTEND_SOURCE_CODE}" HAVE_REG_STARTEND)
IF (HAVE_REG_STARTEND)
     ADD_DEFINITIONS(-DHAVE_REG_STARTEND)
ENDIF (HAVE_REG_STARTEND)
```

So, I've fixed it as below.

```
conf_data = configuration_data()
if cc.has_header_symbol('regex.h', 'REG_STARTEND')
  conf_data.set('HAVE_REG_STARTEND', 1)
endif
```