### PR TITLE
meson.build: Fix prefix not inherited from parent project

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,6 @@ project('freediameter', 'c',
     default_options : [
         'warning_level=1',
         'c_std=gnu89',
-        'prefix=/usr',
     ],
 )
 


### PR DESCRIPTION
When building open5gs with meson 1.8.0 and passing a prefix ("--prefix") to it, it was noted that "get_option('prefix')" in
subprojects/freeDiameter/meson.build was not inheriting the value set on the cmdline. This somehow gets fixed by removing the prefix option from the "default_options" dict.